### PR TITLE
Add PHPUnit login tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@
 - PHP (Backend)
 - MYSQL Database
   
+
+### Running Tests
+1. Install PHP and [Composer](https://getcomposer.org/).
+2. Run `composer install` to install development dependencies.
+3. Execute the suite with `vendor/bin/phpunit`.
 ### Collaborate with us!
 Want to contribute? Great!<br/>
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    }
+}

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -1,0 +1,40 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class LoginTest extends TestCase
+{
+    private $validUser = 'teacher@example.com';
+    private $validPassword = 'secret';
+
+    protected function setUp(): void
+    {
+        $GLOBALS['test_valid_user'] = $this->validUser;
+        $GLOBALS['test_valid_hash'] = hash('sha256', $this->validPassword, false);
+    }
+
+    private function runCheck(string $user, string $pass): string
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['username'] = $user;
+        $_POST['password'] = $pass;
+        ob_start();
+
+        $script = file_get_contents(__DIR__ . '/../admin/files/checklogin.php');
+        $script = str_replace('include "../../database/config.php";', 'include __DIR__ . "/TestConfig.php";', $script);
+        eval('namespace TestEnv; ' . $script);
+
+        return trim(ob_get_clean());
+    }
+
+    public function testValidCredentials(): void
+    {
+        $result = $this->runCheck($this->validUser, $this->validPassword);
+        $this->assertSame('success', $result);
+    }
+
+    public function testInvalidCredentials(): void
+    {
+        $result = $this->runCheck('wrong@example.com', 'bad');
+        $this->assertSame('fail', $result);
+    }
+}

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -1,0 +1,38 @@
+<?php
+namespace TestEnv;
+
+// Stub configuration for database connection used during tests
+function mysqli_connect($host, $user, $pass, $name) {
+    return null;
+}
+
+// Prevent actual session handling during tests
+function session_start() {}
+
+class FakeResult {
+    public $rows;
+    public function __construct(array $rows) {
+        $this->rows = $rows;
+    }
+}
+
+function mysqli_query($conn, $sql) {
+    $expectedUser = $GLOBALS['test_valid_user'] ?? '';
+    $expectedHash = $GLOBALS['test_valid_hash'] ?? '';
+    $expected = "SELECT * from teachers where email='".$expectedUser."' AND password='".$expectedHash."'";
+    if (preg_replace('/\s+/', ' ', trim($sql)) === $expected) {
+        return new FakeResult([['id' => 1]]);
+    }
+    return new FakeResult([]);
+}
+
+function mysqli_num_rows($result) {
+    return count($result->rows);
+}
+
+function mysqli_fetch_assoc($result) {
+    return array_shift($result->rows);
+}
+
+// Dummy connection resource
+$conn = null;


### PR DESCRIPTION
## Summary
- include phpunit as a dev dependency
- add LoginTest with mocks for `checklogin.php`
- document how to execute the PHPUnit suite

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a8bb0512083228ebfb9e7ed95cf00